### PR TITLE
check for vmId before setting on.confirmation listener

### DIFF
--- a/src/hooks/useArbTokenBridge.ts
+++ b/src/hooks/useArbTokenBridge.ts
@@ -137,12 +137,9 @@ export const useArbTokenBridge = (
   ETH METHODS:
   */
   const updateEthBalances = useCallback(async () => {
-    if (!arbProvider)
-      throw new Error('updateEthBalances no arb provider')
-    if (!vmId)
-      throw new Error('updateEthBalances no vmId')
-    if (!walletAddress)
-      throw new Error('updateEthBalances walletAddress')
+    if (!arbProvider) throw new Error('updateEthBalances no arb provider')
+    if (!vmId) throw new Error('updateEthBalances no vmId')
+    if (!walletAddress) throw new Error('updateEthBalances walletAddress')
 
     const inboxManager = await arbProvider.globalInboxConn()
     const ethWallet = arbProvider.provider.getSigner(walletIndex)
@@ -599,7 +596,7 @@ export const useArbTokenBridge = (
         })
       }
     }
-  }, [arbProvider, updateAllBalances])
+  }, [arbProvider, updateAllBalances, vmId])
 
   // TODO replace IIFEs with Promise.allSettled once available
   useEffect(() => {

--- a/src/hooks/useArbTokenBridge.ts
+++ b/src/hooks/useArbTokenBridge.ts
@@ -137,8 +137,12 @@ export const useArbTokenBridge = (
   ETH METHODS:
   */
   const updateEthBalances = useCallback(async () => {
-    if (!arbProvider || !vmId || !walletAddress)
+    if (!arbProvider)
       throw new Error('updateEthBalances no arb provider')
+    if (!vmId)
+      throw new Error('updateEthBalances no vmId')
+    if (!walletAddress)
+      throw new Error('updateEthBalances walletAddress')
 
     const inboxManager = await arbProvider.globalInboxConn()
     const ethWallet = arbProvider.provider.getSigner(walletIndex)
@@ -578,7 +582,7 @@ export const useArbTokenBridge = (
   }
 
   useEffect(() => {
-    if (arbProvider) {
+    if (arbProvider && vmId) {
       arbProvider.arbRollupConn().then(rollup => {
         const {
           name: confirmedEvent


### PR DESCRIPTION
Hacky fix, still don't fully understand the core of the issue; for some reason, once when confirmation event fires, updateEthBalance gets called with a stale (undefined) value for vmId, and throws an error (are you seeing this too?).

The events gets unset, so not sure why this is happening, but this just prevents it from getting set to begin with before vmId is defined. 