### PR TITLE
don't throw error if contract not deployed on addToken

### DIFF
--- a/src/hooks/useArbTokenBridge.ts
+++ b/src/hooks/useArbTokenBridge.ts
@@ -807,7 +807,10 @@ export const useArbTokenBridge = (
 
       const isEthContract =
         (await arbProvider.ethProvider.getCode(contractAddress)).length > 2
-      if (!isEthContract) throw Error('contract is not deployed on eth')
+      if (!isEthContract) {
+        console.warn('contract not deployed');
+        return ''
+      }
       else if (bridgeTokens[contractAddress]) throw Error('token already added')
 
       const inboxManager = await arbProvider.globalInboxConn()


### PR DESCRIPTION
Shouldn't be considered an error-throwing-level offense; can cause page loading issues if you switch from a supported network to an unsupported one (across page loads) 