### PR TITLE
use arb-provider-ethers as peer dep, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arb-token-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "private": true,
   "dependencies": {
@@ -44,6 +44,8 @@
   ],
   "peerDependencies": {
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "arb-provider-ethers": "^0.5.0"
+
   }
 }


### PR DESCRIPTION
This + upgrading the yarn.lock in uniswap should fix the versioning issue.